### PR TITLE
V0.1

### DIFF
--- a/gemini.lazyload.js
+++ b/gemini.lazyload.js
@@ -33,7 +33,9 @@ define(['gemini', 'gemini.fold'], function($){
       appear          : null,
       load            : null,
       placeholder     : "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
-      bindWindow      : false
+      bindWindow      : false,
+      fallback_image  : null,
+      fallback_timer  : 3000
     },
 
     // the method that initiates DOM listeners and manipulation
@@ -105,6 +107,13 @@ define(['gemini', 'gemini.fold'], function($){
                 }
               })
               .attr("src", imgUrl);
+
+            /* If image doesn't load, display fallback_image */
+            if (plugin.settings.fallback_image !== null){
+              setTimeout(function(){
+                $img.attr( 'src', plugin.settings.fallback_image );
+              }, plugin.settings.fallback_timer );
+            }
           }
         });
 

--- a/gemini.lazyload.js
+++ b/gemini.lazyload.js
@@ -34,8 +34,8 @@ define(['gemini', 'gemini.fold'], function($){
       load            : null,
       placeholder     : "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
       bindWindow      : false,
-      fallbackImage  : null,
-      fallbackTimer  : 3000
+      fallbackImage   : null,
+      fallbackTimer   : 3000
     },
 
     // the method that initiates DOM listeners and manipulation

--- a/gemini.lazyload.js
+++ b/gemini.lazyload.js
@@ -109,8 +109,8 @@ define(['gemini', 'gemini.fold'], function($){
               .attr("src", imgUrl);
 
             /* If image doesn't load, display fallbackImage */
-            if (plugin.settings.fallbackImage !== null){
-              setTimeout(function(){
+            if (plugin.settings.fallbackImage !== null) {
+              setTimeout(function() {
                 $img.attr( 'src', plugin.settings.fallbackImage );
               }, plugin.settings.fallbackTimer );
             }

--- a/gemini.lazyload.js
+++ b/gemini.lazyload.js
@@ -34,8 +34,8 @@ define(['gemini', 'gemini.fold'], function($){
       load            : null,
       placeholder     : "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
       bindWindow      : false,
-      fallback_image  : null,
-      fallback_timer  : 3000
+      fallbackImage  : null,
+      fallbackTimer  : 3000
     },
 
     // the method that initiates DOM listeners and manipulation
@@ -108,11 +108,11 @@ define(['gemini', 'gemini.fold'], function($){
               })
               .attr("src", imgUrl);
 
-            /* If image doesn't load, display fallback_image */
-            if (plugin.settings.fallback_image !== null){
+            /* If image doesn't load, display fallbackImage */
+            if (plugin.settings.fallbackImage !== null){
               setTimeout(function(){
-                $img.attr( 'src', plugin.settings.fallback_image );
-              }, plugin.settings.fallback_timer );
+                $img.attr( 'src', plugin.settings.fallbackImage );
+              }, plugin.settings.fallbackTimer );
             }
           }
         });


### PR DESCRIPTION
![fallback_image_gif](https://user-images.githubusercontent.com/17207891/57647576-50ee1a00-7591-11e9-8831-e585b83abad0.gif)

Problem: Sometimes images just don't load. It'd be nice if gemini-lazyload took this into account.

Solution: With this commit, we can make a call to lazyload with a fallback_image URL and/or a fallback_timer to define what image to display when the timer on fallback_timer is up.